### PR TITLE
인터넷 게이트웨이 기능 추가

### DIFF
--- a/docs/data-sources/nhncloud_networking_internet_gateway_v2.md
+++ b/docs/data-sources/nhncloud_networking_internet_gateway_v2.md
@@ -1,0 +1,32 @@
+# Data Source: nhncloud_networking_internet_gateway_v2
+
+## Example Usage
+
+```
+data "nhncloud_networking_internet_gateway_v2" "gw" {
+  name = "tf-igw-01"
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) The region name in which the internet gateway to query exists.
+* `id` - (Optional) The internet gateway ID to query.
+* `name` - (Optional) The internet gateway name to query.
+* `external_network_id` - (Optional) The external network ID connected to the internet gateway to query.
+* `routingtable_id` - (Optional) The ID of the routing table the internet gateway to query is attached to.
+* `tenant_id` - (Optional) The tenant ID to which the internet gateway to query belongs.
+
+## Attribute Reference
+
+`id` is set to the ID of the found internet gateway. In addition, the following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `external_network_id` - See Argument Reference above.
+* `routingtable_id` - See Argument Reference above.
+* `tenant_id` - See Argument Reference above.
+* `state` - The status of the internet gateway.
+* `create_time` - The time the internet gateway was created (UTC).
+* `migrate_status` - The processing status while the internet gateway is being moved to another gateway server for maintenance.
+* `migrate_error` - The error message when an error occurs while the internet gateway is being moved for maintenance.

--- a/docs/resources/nhncloud_networking_internet_gateway_v2.md
+++ b/docs/resources/nhncloud_networking_internet_gateway_v2.md
@@ -1,0 +1,35 @@
+# Resource: nhncloud_networking_internet_gateway_v2
+
+## Example Usage
+
+```
+data "nhncloud_networking_network_v2" "ext" {
+  external = true
+}
+
+resource "nhncloud_networking_internet_gateway_v2" "gw" {
+  name = "tf-igw-01"
+  external_network_id = data.nhncloud_networking_network_v2.ext.id
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The name of the internet gateway. Changing this creates a new internet gateway.
+* `external_network_id` - (Required) The ID of the external network the internet gateway connects to. Changing this creates a new internet gateway.
+* `region` - (Optional) The region in which to create the internet gateway. If omitted, the region configured on the provider is used. Changing this creates a new internet gateway.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `external_network_id` - See Argument Reference above.
+* `id` - The ID of the internet gateway.
+* `routingtable_id` - The ID of the routing table the internet gateway is attached to, when one is connected.
+* `state` - The status of the internet gateway. A newly created gateway stays `unavailable` until it is attached to a routing table.
+* `create_time` - The time the internet gateway was created (UTC).
+* `tenant_id` - The ID of the tenant that owns the internet gateway.
+* `migrate_status` - The processing status while the internet gateway is being moved to another gateway server for maintenance.
+* `migrate_error` - The error message when an error occurs while the internet gateway is being moved for maintenance.

--- a/nhncloud/data_source_nhncloud_networking_internet_gateway_v2.go
+++ b/nhncloud/data_source_nhncloud_networking_internet_gateway_v2.go
@@ -1,0 +1,132 @@
+package nhncloud
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/nhn-cloud/nhncloud.gophercloud/nhncloud/networking/v2/internetgateways"
+)
+
+func dataSourceNetworkingInternetGatewayV2() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceNetworkingInternetGatewayV2Read,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"region": {
+				// The region in which the resource is located.
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				// 인터넷 게이트웨이 이름
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"external_network_id": {
+				// 인터넷 게이트웨이가 연결할 외부 네트워크 ID
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"routingtable_id": {
+				// 라우팅 테이블과 연결되어 있을 때 인터넷 게이트웨이를 연결한 라우팅 테이블 ID
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"state": {
+				// 인터넷 게이트웨이의 상태.
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				// 인터넷 게이트웨이 생성 시간(UTC)
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tenant_id": {
+				// 인터넷 게이트웨이가 속한 테넌트 ID
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"migrate_status": {
+				// 점검으로 인한 인터넷 게이트웨이 이동 시 처리 상태
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"migrate_error": {
+				// 점검으로 인한 인터넷 게이트웨이 이동 중 오류 발생 시 오류 메시지
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceNetworkingInternetGatewayV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating NHN Cloud networking client: %s", err)
+	}
+
+	listOpts := internetgateways.ListOpts{}
+
+	if v, ok := d.GetOk("id"); ok {
+		listOpts.ID = v.(string)
+	}
+	if v, ok := d.GetOk("name"); ok {
+		listOpts.Name = v.(string)
+	}
+	if v, ok := d.GetOk("external_network_id"); ok {
+		listOpts.ExternalNetworkID = v.(string)
+	}
+	if v, ok := d.GetOk("routingtable_id"); ok {
+		listOpts.RoutingtableID = v.(string)
+	}
+	if v, ok := d.GetOk("tenant_id"); ok {
+		listOpts.TenantID = v.(string)
+	}
+
+	pages, err := internetgateways.List(networkingClient, listOpts).AllPages()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	allInternetGateways, err := internetgateways.ExtractInternetGateways(pages)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if len(allInternetGateways) != 1 {
+		return diag.Errorf("Your query returned %d internet gateways. Please change your search criteria and try again.", len(allInternetGateways))
+	}
+
+	// The list item already carries the full field set for an internet gateway
+	// (identical to Get), so use it directly instead of a second round trip.
+	n := allInternetGateways[0]
+
+	d.SetId(n.ID)
+	d.Set("region", GetRegion(d, config))
+	d.Set("name", n.Name)
+	d.Set("external_network_id", n.ExternalNetworkID)
+	d.Set("routingtable_id", n.RoutingtableID)
+	d.Set("state", n.State)
+	d.Set("create_time", n.CreateTime)
+	d.Set("tenant_id", n.TenantID)
+	d.Set("migrate_status", n.MigrateStatus)
+	d.Set("migrate_error", n.MigrateError)
+	log.Printf("[DEBUG] Retrieved nhncloud_networking_internet_gateway_v2 %s: %#v", d.Id(), n)
+	return nil
+}

--- a/nhncloud/provider.go
+++ b/nhncloud/provider.go
@@ -259,6 +259,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"nhncloud_networking_internet_gateway_v2":           dataSourceNetworkingInternetGatewayV2(),
 			"nhncloud_blockstorage_availability_zones_v3":       dataSourceBlockStorageAvailabilityZonesV3(),
 			"nhncloud_blockstorage_snapshot_v2":                 dataSourceBlockStorageSnapshotV2(),
 			"nhncloud_blockstorage_snapshot_v3":                 dataSourceBlockStorageSnapshotV3(),
@@ -315,6 +316,7 @@ func Provider() *schema.Provider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"nhncloud_networking_internet_gateway_v2":            resourceNetworkingInternetGatewayV2(),
 			"nhncloud_blockstorage_qos_association_v3":           resourceBlockStorageQosAssociationV3(),
 			"nhncloud_blockstorage_qos_v3":                       resourceBlockStorageQosV3(),
 			"nhncloud_blockstorage_quotaset_v2":                  resourceBlockStorageQuotasetV2(),

--- a/nhncloud/resource_nhncloud_networking_internet_gateway_v2.go
+++ b/nhncloud/resource_nhncloud_networking_internet_gateway_v2.go
@@ -1,0 +1,149 @@
+package nhncloud
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/nhn-cloud/nhncloud.gophercloud/nhncloud/networking/v2/internetgateways"
+)
+
+func resourceNetworkingInternetGatewayV2() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceNetworkingInternetGatewayV2Create,
+		ReadContext:   resourceNetworkingInternetGatewayV2Read,
+		DeleteContext: resourceNetworkingInternetGatewayV2Delete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				// The region in which the resource is located.
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"name": {
+				// 인터넷 게이트웨이 이름
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"external_network_id": {
+				// 인터넷 게이트웨이가 연결할 외부 네트워크 ID
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"id": {
+				// 인터넷 게이트웨이 ID
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"routingtable_id": {
+				// 라우팅 테이블과 연결되어 있을 때 인터넷 게이트웨이를 연결한 라우팅 테이블 ID
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				// 인터넷 게이트웨이의 상태.
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"create_time": {
+				// 인터넷 게이트웨이 생성 시간(UTC)
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"tenant_id": {
+				// 인터넷 게이트웨이가 속한 테넌트 ID
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"migrate_status": {
+				// 점검으로 인한 인터넷 게이트웨이 이동 시 처리 상태
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"migrate_error": {
+				// 점검으로 인한 인터넷 게이트웨이 이동 중 오류 발생 시 오류 메시지
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkingInternetGatewayV2Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating NHN Cloud networking client: %s", err)
+	}
+
+	createOpts := internetgateways.CreateOpts{
+		Name:              d.Get("name").(string),
+		ExternalNetworkID: d.Get("external_network_id").(string),
+	}
+
+	log.Printf("[DEBUG] nhncloud_networking_internet_gateway_v2 create options: %#v", createOpts)
+	n, err := internetgateways.Create(networkingClient, createOpts).Extract()
+	if err != nil {
+		return diag.Errorf("Error creating nhncloud_networking_internet_gateway_v2: %s", err)
+	}
+
+	d.SetId(n.ID)
+	log.Printf("[DEBUG] Created nhncloud_networking_internet_gateway_v2 %s: %#v", n.ID, n)
+	return resourceNetworkingInternetGatewayV2Read(ctx, d, meta)
+}
+
+func resourceNetworkingInternetGatewayV2Read(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating NHN Cloud networking client: %s", err)
+	}
+
+	n, err := internetgateways.Get(networkingClient, d.Id()).Extract()
+	if err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error getting nhncloud_networking_internet_gateway_v2"))
+	}
+
+	log.Printf("[DEBUG] Retrieved nhncloud_networking_internet_gateway_v2 %s: %#v", d.Id(), n)
+
+	d.Set("region", GetRegion(d, config))
+	d.Set("name", n.Name)
+	d.Set("external_network_id", n.ExternalNetworkID)
+	d.Set("routingtable_id", n.RoutingtableID)
+	d.Set("state", n.State)
+	d.Set("create_time", n.CreateTime)
+	d.Set("tenant_id", n.TenantID)
+	d.Set("migrate_status", n.MigrateStatus)
+	d.Set("migrate_error", n.MigrateError)
+	return nil
+}
+
+func resourceNetworkingInternetGatewayV2Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	config := meta.(*Config)
+	networkingClient, err := config.NetworkingV2Client(GetRegion(d, config))
+	if err != nil {
+		return diag.Errorf("Error creating NHN Cloud networking client: %s", err)
+	}
+
+	if err := internetgateways.Delete(networkingClient, d.Id()).ExtractErr(); err != nil {
+		return diag.FromErr(CheckDeleted(d, err, "Error deleting nhncloud_networking_internet_gateway_v2"))
+	}
+
+	d.SetId("")
+	return nil
+}


### PR DESCRIPTION
## What & why

Add Terraform support for the NHN Cloud Internet Gateway, generated from the public API guide by the `tfcodegen` pipeline (task tc-iaas-compute/3289).

- Resource `nhncloud_networking_internet_gateway_v2` (create/read/delete; all args ForceNew since the API has no update)
  - args: `name` (required), `external_network_id` (required), `region` (optional)
- Data source `nhncloud_networking_internet_gateway_v2` (lookup by `id`/`name`/`external_network_id`/`routingtable_id`/`tenant_id`, single-result)
- Docs for both under `docs/resources` and `docs/data-sources`
- Registered in `provider.go` (ResourcesMap + DataSourcesMap)

## Depends on

Paired SDK PR: `nhn/nhncloud.gophercloud` — adds the `networking/v2/internetgateways` package.

**This branch does not build until that SDK change is published.** `go.mod` still pins `nhncloud.gophercloud v1.0.12`, which does not contain the new package. After the SDK PR merges and a new version is tagged:

```
go get github.com/nhn-cloud/nhncloud.gophercloud@<new-version>
go mod tidy
```

Then this PR builds with no `replace` directive.

## Verification (via local replace build)

- `go build ./...` and `go vet ./...` pass with the SDK package present
- Real round-trip on KR1 alpha through a locally built provider mirror: `terraform plan` → `apply` (internet gateway created) → `destroy` (cleaned up), no leftover resources

## Checklist (before merge)

- [ ] SDK PR merged and new `nhncloud.gophercloud` version published
- [ ] `go.mod` bumped to that version; `go mod tidy` run; builds without `replace`

## Dooray
- https://nhnent.dooray.com/project/tasks/4286540582523353096
