### PR TITLE
Terraform > provider 1.0.10-dev1 클러스터·노드그룹 조회 시 존재하지 않는 flavor/image 필드에 state 설정을 시도해 ERROR 발생

### DIFF
--- a/nhncloud/data_source_nhncloud_kubernetes_cluster_v1.go
+++ b/nhncloud/data_source_nhncloud_kubernetes_cluster_v1.go
@@ -197,7 +197,6 @@ func dataSourceKubernetesClusterRead(ctx context.Context, d *schema.ResourceData
 	d.Set("container_version", c.ContainerVersion)
 	d.Set("create_timeout", c.CreateTimeout)
 	d.Set("docker_volume_size", c.DockerVolumeSize)
-	d.Set("flavor", c.FlavorID)
 	d.Set("keypair", c.KeyPair)
 	d.Set("node_count", c.NodeCount)
 	d.Set("node_addresses", c.NodeAddresses)

--- a/nhncloud/data_source_nhncloud_kubernetes_nodegroup_v1.go
+++ b/nhncloud/data_source_nhncloud_kubernetes_nodegroup_v1.go
@@ -147,8 +147,6 @@ func dataSourceKubernetesNodeGroupRead(ctx context.Context, d *schema.ResourceDa
 	d.Set("node_count", nodeGroup.NodeCount)
 	d.Set("min_node_count", nodeGroup.MinNodeCount)
 	d.Set("max_node_count", nodeGroup.MaxNodeCount)
-	d.Set("image", nodeGroup.ImageID)
-	d.Set("flavor", nodeGroup.FlavorID)
 	d.Set("image_id", nodeGroup.ImageID)
 	d.Set("flavor_id", nodeGroup.FlavorID)
 	d.Set("uuid", nodeGroup.UUID)


### PR DESCRIPTION
## 작업 내용

NKS 클러스터·노드그룹 데이터소스 read가 스키마에 없는 `flavor`/`image` 키에 `d.Set()`을 호출해 Plugin SDK가 `Invalid address to set` ERROR를 남기던 문제를 수정. 해당 3줄만 제거하고 `flavor_id`/`image_id`는 유지해 데이터 손실 없음. 1.0.9에도 있던 기존 결함

## Dooray Info

- #cloud-bugs/1931
- [NKS][PUBLIC_KR2_ALPHA] Terraform > provider 1.0.10-dev1 클러스터·노드그룹 조회 시 존재하지 않는 flavor/image 필드에 state 설정을 시도해 ERROR 발생
- https://nhnent.dooray.com/project/tasks/4388107988314534974

🤖 Generated with [Claude Code](https://claude.com/claude-code)
